### PR TITLE
Forced Error action stop on missing MSAL module

### DIFF
--- a/SetExemptStatus/run.ps1
+++ b/SetExemptStatus/run.ps1
@@ -25,9 +25,9 @@ $Exempt = $(
 # Attempting to import the needed Modules
 try {
     Write-Output "Importing the MSAL.PS module"
-    Import-Module .\modules\MSAL.PS\4.21.0.1\MSAL.PS.psd1 -Force
+    Import-Module .\modules\MSAL.PS\4.21.0.1\MSAL.PS.psd1 -Force -ErrorAction stop
     Write-Output "Importing the 'CustomToolkit' module"
-    Import-Module .\Modules\CustomToolkit\CustomToolkit.psm1 -Force
+    Import-Module .\Modules\CustomToolkit\CustomToolkit.psm1 -Force -ErrorAction stop
 }
 catch {
     Throw 'Failed to import the required modules'

--- a/TimedGroupCheck/run.ps1
+++ b/TimedGroupCheck/run.ps1
@@ -15,7 +15,7 @@ Write-Host "PowerShell timer trigger function ran! TIME: $currentUTCtime"
 # Attempting to import the needed Modules
 try {
     Write-Output "Importing the MSAL.PS module"
-    Import-Module .\Modules\MSAL.PS\4.21.0.1\MSAL.PS.psd1
+    Import-Module .\Modules\MSAL.PS\4.21.0.1\MSAL.PS.psd1 -Force -ErrorAction stop
 }
 catch {
     Throw 'Failed to import the MSAL.PS Module'


### PR DESCRIPTION
The MSAL module is required for these azure functions, using ErrorAction Stop to ensure that the try catch triggers and ends the script if an exception occurs.